### PR TITLE
Resizable handle flag `hideHandlesWhenNotResizable` added, extend example

### DIFF
--- a/packages/flutter_box_transform/example/lib/main.dart
+++ b/packages/flutter_box_transform/example/lib/main.dart
@@ -15,7 +15,6 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    
     return AdaptiveTheme(
       light: ThemeData(
         useMaterial3: true,
@@ -344,8 +343,17 @@ class _PlaygroundState extends State<Playground> with WidgetsBindingObserver {
                 ),
                 if (model.clampingEnabled && model.playgroundArea != null)
                   const ClampingRect(),
-                ImageBox(rect:model.rect, flip:model.flip, imageAsset:'assets/images/landscape2.jpg', onChanged:model.onRectChanged),
-                if(model.showSecondImageBox) ImageBox(rect:model.rect2, flip:model.flip2, imageAsset:'assets/images/landscape.jpg', onChanged:model.onRect2Changed),
+                ImageBox(
+                    rect: model.rect,
+                    flip: model.flip,
+                    imageAsset: 'assets/images/landscape2.jpg',
+                    onChanged: model.onRectChanged),
+                if (model.showSecondImageBox)
+                  ImageBox(
+                      rect: model.rect2,
+                      flip: model.flip2,
+                      imageAsset: 'assets/images/landscape.jpg',
+                      onChanged: model.onRect2Changed),
               ],
             ),
           ),
@@ -357,8 +365,12 @@ class _PlaygroundState extends State<Playground> with WidgetsBindingObserver {
 }
 
 class ImageBox extends StatefulWidget {
-  const ImageBox({super.key, required this.rect, required this.flip, required this.imageAsset,
-        required this.onChanged});
+  const ImageBox(
+      {super.key,
+      required this.rect,
+      required this.flip,
+      required this.imageAsset,
+      required this.onChanged});
 
   final Rect rect;
   final Flip flip;
@@ -707,7 +719,8 @@ class ControlPanel extends StatelessWidget {
                       scale: 0.7,
                       child: Switch(
                         value: model.hideHandlesWhenNotResizable,
-                        onChanged: (value) => model.toggleHideHandlesWhenNotResizable(value),
+                        onChanged: (value) =>
+                            model.toggleHideHandlesWhenNotResizable(value),
                       ),
                     ),
                   ),
@@ -741,7 +754,8 @@ class ControlPanel extends StatelessWidget {
                       scale: 0.7,
                       child: Switch(
                         value: model.showSecondImageBox,
-                        onChanged: (value) => model.toggleShowSecondImageBox(value),
+                        onChanged: (value) =>
+                            model.toggleShowSecondImageBox(value),
                       ),
                     ),
                   ),
@@ -1627,4 +1641,3 @@ class SectionHeader extends StatelessWidget {
     );
   }
 }
-

--- a/packages/flutter_box_transform/example/lib/main.dart
+++ b/packages/flutter_box_transform/example/lib/main.dart
@@ -796,8 +796,8 @@ class PositionControls extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Row(
-                children: [
+              Row(
+                children: const [
                   Expanded(child: Label('X')),
                   SizedBox(width: 16),
                   Expanded(child: Label('Y')),
@@ -816,8 +816,8 @@ class PositionControls extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: 16),
-              const Row(
-                children: [
+              Row(
+                children: const [
                   Expanded(child: Label('WIDTH')),
                   SizedBox(width: 16),
                   Expanded(child: Label('HEIGHT')),
@@ -836,8 +836,8 @@ class PositionControls extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: 16),
-              const Row(
-                children: [
+              Row(
+                children: const [
                   Expanded(child: Label('ASPECT RATIO')),
                 ],
               ),
@@ -989,14 +989,14 @@ class FlipControls extends StatelessWidget {
                     ],
                     selectedColor: Theme.of(context).colorScheme.primary,
                     constraints: const BoxConstraints.tightFor(height: 32),
-                    children: const [
+                    children: [
                       Tooltip(
                         message: 'Flip Horizontally',
-                        waitDuration: Duration(milliseconds: 500),
+                        waitDuration: const Duration(milliseconds: 500),
                         child: Padding(
-                          padding: EdgeInsets.symmetric(horizontal: 8),
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
                           child: Row(
-                            children: [
+                            children: const [
                               ImageIcon(
                                 AssetImage('assets/images/ic_flip.png'),
                                 size: 20,
@@ -1009,11 +1009,11 @@ class FlipControls extends StatelessWidget {
                       ),
                       Tooltip(
                         message: 'Flip Vertically',
-                        waitDuration: Duration(milliseconds: 500),
+                        waitDuration: const Duration(milliseconds: 500),
                         child: Padding(
-                          padding: EdgeInsets.symmetric(horizontal: 8),
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
                           child: Row(
-                            children: [
+                            children: const [
                               RotatedBox(
                                 quarterTurns: 1,
                                 child: ImageIcon(
@@ -1153,8 +1153,8 @@ class _ClampingControlsState extends State<ClampingControls> {
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          const Row(
-                            children: [
+                          Row(
+                            children: const [
                               Expanded(child: Label('LEFT')),
                               SizedBox(width: 16),
                               Expanded(child: Label('TOP')),
@@ -1201,8 +1201,8 @@ class _ClampingControlsState extends State<ClampingControls> {
                             ],
                           ),
                           const SizedBox(height: 16),
-                          const Row(
-                            children: [
+                          Row(
+                            children: const [
                               Expanded(child: Label('RIGHT')),
                               SizedBox(width: 16),
                               Expanded(child: Label('BOTTOM')),
@@ -1401,8 +1401,8 @@ class _ConstraintsControlsState extends State<ConstraintsControls> {
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          const Row(
-                            children: [
+                          Row(
+                            children: const [
                               Expanded(child: Label('Min W')),
                               SizedBox(width: 16),
                               Expanded(child: Label('Min H')),
@@ -1457,8 +1457,8 @@ class _ConstraintsControlsState extends State<ConstraintsControls> {
                             ],
                           ),
                           const SizedBox(height: 16),
-                          const Row(
-                            children: [
+                          Row(
+                            children: const [
                               Expanded(child: Label('Max W')),
                               SizedBox(width: 16),
                               Expanded(child: Label('Max H')),

--- a/packages/flutter_box_transform/example/lib/main.dart
+++ b/packages/flutter_box_transform/example/lib/main.dart
@@ -65,6 +65,8 @@ class PlaygroundModel with ChangeNotifier {
   Rect rect2 = Rect.zero;
   Flip flip2 = Flip.none;
 
+  int lastRectAdjusted = 1; // 1 or 2
+
   Rect clampingRect = Rect.largest;
   Rect? playgroundArea;
   late BoxConstraints constraints = const BoxConstraints(
@@ -100,6 +102,8 @@ class PlaygroundModel with ChangeNotifier {
     );
     flip2 = Flip.none;
 
+    lastRectAdjusted = 1;
+
     clampingRect = Rect.fromLTWH(
       0,
       0,
@@ -124,12 +128,14 @@ class PlaygroundModel with ChangeNotifier {
   void onRectChanged(UITransformResult result) {
     rect = result.rect;
     flip = result is UIResizeResult ? result.flip : flip;
+    lastRectAdjusted = 1;
     notifyListeners();
   }
 
   void onRect2Changed(UITransformResult result) {
     rect2 = result.rect;
     flip2 = result is UIResizeResult ? result.flip : flip;
+    lastRectAdjusted = 2;
     notifyListeners();
   }
 
@@ -172,11 +178,13 @@ class PlaygroundModel with ChangeNotifier {
 
   void flipHorizontally() {
     flip = Flip.fromValue(flip.horizontalValue * -1, flip.verticalValue);
+    flip2 = Flip.fromValue(flip2.horizontalValue * -1, flip2.verticalValue);
     notifyListeners();
   }
 
   void flipVertically() {
     flip = Flip.fromValue(flip.horizontalValue, flip.verticalValue * -1);
+    flip2 = Flip.fromValue(flip2.horizontalValue, flip2.verticalValue * -1);
     notifyListeners();
   }
 
@@ -776,12 +784,12 @@ class PositionControls extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final PlaygroundModel model = context.watch<PlaygroundModel>();
-    final Rect rect = model.rect;
+    final Rect rect = model.lastRectAdjusted==1 ? model.rect : model.rect2;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       mainAxisSize: MainAxisSize.min,
       children: [
-        const SectionHeader('POSITION'),
+        SectionHeader('POSITION${model.lastRectAdjusted==2?" of SECOND IMAGE":""}'),
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
           child: Column(

--- a/packages/flutter_box_transform/example/lib/main.dart
+++ b/packages/flutter_box_transform/example/lib/main.dart
@@ -784,12 +784,13 @@ class PositionControls extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final PlaygroundModel model = context.watch<PlaygroundModel>();
-    final Rect rect = model.lastRectAdjusted==1 ? model.rect : model.rect2;
+    final Rect rect = model.lastRectAdjusted == 1 ? model.rect : model.rect2;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       mainAxisSize: MainAxisSize.min,
       children: [
-        SectionHeader('POSITION${model.lastRectAdjusted==2?" of SECOND IMAGE":""}'),
+        SectionHeader(
+            'POSITION${model.lastRectAdjusted == 2 ? " of SECOND IMAGE" : ""}'),
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
           child: Column(

--- a/packages/flutter_box_transform/lib/src/transformable_box.dart
+++ b/packages/flutter_box_transform/lib/src/transformable_box.dart
@@ -220,6 +220,10 @@ class TransformableBox extends StatefulWidget {
   /// Whether the box is resizable or not. Setting this to false will disable
   /// all resizing operations.
   final bool resizable;
+  
+  /// Whether the box should hide the corner/side resize controls when [resizable] is
+  /// false.
+  final bool hideHandlesWhenNotResizable;
 
   /// Whether the box is movable or not. Setting this to false will disable
   /// all moving operations.
@@ -263,6 +267,7 @@ class TransformableBox extends StatefulWidget {
     this.onTerminalHeightReached,
     this.onTerminalSizeReached,
     this.resizable = true,
+    this.hideHandlesWhenNotResizable = true,
     this.movable = true,
     this.flipWhileResizing = true,
     this.flipChild = true,
@@ -336,6 +341,7 @@ class _TransformableBoxState extends State<TransformableBox> {
         ..constraints = widget.constraints
         ..resolveResizeModeCallback = widget.resolveResizeModeCallback
         ..resizable = widget.resizable
+        ..hideHandlesWhenNotResizable = widget.hideHandlesWhenNotResizable
         ..movable = widget.movable
         ..flipWhileResizing = widget.flipWhileResizing
         ..flipChild = widget.flipChild;
@@ -368,6 +374,10 @@ class _TransformableBoxState extends State<TransformableBox> {
 
     if (oldWidget.resizable != widget.resizable) {
       controller.resizable = widget.resizable;
+    }
+
+    if(oldWidget.hideHandlesWhenNotResizable != widget.hideHandlesWhenNotResizable) {
+      controller.hideHandlesWhenNotResizable = widget.hideHandlesWhenNotResizable;
     }
 
     if (oldWidget.movable != widget.movable) {
@@ -482,7 +492,7 @@ class _TransformableBoxState extends State<TransformableBox> {
               ),
             ),
           ),
-          if(controller.resizable) for (final handle in HandlePosition.corners)
+          if(controller.resizable || !controller.hideHandlesWhenNotResizable) for (final handle in HandlePosition.corners)
             _CornerHandleWidget(
               key: ValueKey(handle),
               handlePosition: handle,
@@ -492,7 +502,7 @@ class _TransformableBoxState extends State<TransformableBox> {
               onPointerUpdate: onHandlePanUpdate,
               onPointerUp: onHandlePanEnd,
             ),
-          if(controller.resizable) for (final handle in HandlePosition.sides)
+          if(controller.resizable || !controller.hideHandlesWhenNotResizable) for (final handle in HandlePosition.sides)
             _SideHandleWidget(
               key: ValueKey(handle),
               handlePosition: handle,

--- a/packages/flutter_box_transform/lib/src/transformable_box.dart
+++ b/packages/flutter_box_transform/lib/src/transformable_box.dart
@@ -220,7 +220,7 @@ class TransformableBox extends StatefulWidget {
   /// Whether the box is resizable or not. Setting this to false will disable
   /// all resizing operations.
   final bool resizable;
-  
+
   /// Whether the box should hide the corner/side resize controls when [resizable] is
   /// false.
   final bool hideHandlesWhenNotResizable;
@@ -376,8 +376,10 @@ class _TransformableBoxState extends State<TransformableBox> {
       controller.resizable = widget.resizable;
     }
 
-    if(oldWidget.hideHandlesWhenNotResizable != widget.hideHandlesWhenNotResizable) {
-      controller.hideHandlesWhenNotResizable = widget.hideHandlesWhenNotResizable;
+    if (oldWidget.hideHandlesWhenNotResizable !=
+        widget.hideHandlesWhenNotResizable) {
+      controller.hideHandlesWhenNotResizable =
+          widget.hideHandlesWhenNotResizable;
     }
 
     if (oldWidget.movable != widget.movable) {
@@ -492,26 +494,28 @@ class _TransformableBoxState extends State<TransformableBox> {
               ),
             ),
           ),
-          if(controller.resizable || !controller.hideHandlesWhenNotResizable) for (final handle in HandlePosition.corners)
-            _CornerHandleWidget(
-              key: ValueKey(handle),
-              handlePosition: handle,
-              handleTapSize: widget.handleTapSize,
-              builder: widget.cornerHandleBuilder,
-              onPointerDown: onHandlePanStart,
-              onPointerUpdate: onHandlePanUpdate,
-              onPointerUp: onHandlePanEnd,
-            ),
-          if(controller.resizable || !controller.hideHandlesWhenNotResizable) for (final handle in HandlePosition.sides)
-            _SideHandleWidget(
-              key: ValueKey(handle),
-              handlePosition: handle,
-              handleTapSize: widget.handleTapSize,
-              builder: widget.sideHandleBuilder,
-              onPointerDown: onHandlePanStart,
-              onPointerUpdate: onHandlePanUpdate,
-              onPointerUp: onHandlePanEnd,
-            ),
+          if (controller.resizable || !controller.hideHandlesWhenNotResizable)
+            for (final handle in HandlePosition.corners)
+              _CornerHandleWidget(
+                key: ValueKey(handle),
+                handlePosition: handle,
+                handleTapSize: widget.handleTapSize,
+                builder: widget.cornerHandleBuilder,
+                onPointerDown: onHandlePanStart,
+                onPointerUpdate: onHandlePanUpdate,
+                onPointerUp: onHandlePanEnd,
+              ),
+          if (controller.resizable || !controller.hideHandlesWhenNotResizable)
+            for (final handle in HandlePosition.sides)
+              _SideHandleWidget(
+                key: ValueKey(handle),
+                handlePosition: handle,
+                handleTapSize: widget.handleTapSize,
+                builder: widget.sideHandleBuilder,
+                onPointerDown: onHandlePanStart,
+                onPointerUpdate: onHandlePanUpdate,
+                onPointerUp: onHandlePanEnd,
+              ),
         ],
       ),
     );

--- a/packages/flutter_box_transform/lib/src/transformable_box.dart
+++ b/packages/flutter_box_transform/lib/src/transformable_box.dart
@@ -482,7 +482,7 @@ class _TransformableBoxState extends State<TransformableBox> {
               ),
             ),
           ),
-          for (final handle in HandlePosition.corners)
+          if(controller.resizable) for (final handle in HandlePosition.corners)
             _CornerHandleWidget(
               key: ValueKey(handle),
               handlePosition: handle,
@@ -492,7 +492,7 @@ class _TransformableBoxState extends State<TransformableBox> {
               onPointerUpdate: onHandlePanUpdate,
               onPointerUp: onHandlePanEnd,
             ),
-          for (final handle in HandlePosition.sides)
+          if(controller.resizable) for (final handle in HandlePosition.sides)
             _SideHandleWidget(
               key: ValueKey(handle),
               handlePosition: handle,

--- a/packages/flutter_box_transform/lib/src/transformable_box_controller.dart
+++ b/packages/flutter_box_transform/lib/src/transformable_box_controller.dart
@@ -154,7 +154,6 @@ class TransformableBoxController extends ChangeNotifier {
     notifyListeners();
   }
 
-
   /// Whether to allow flipping of the box while resizing. If this is set to
   /// true, the box will flip when the user drags the handles to opposite
   /// corners of the rect.

--- a/packages/flutter_box_transform/lib/src/transformable_box_controller.dart
+++ b/packages/flutter_box_transform/lib/src/transformable_box_controller.dart
@@ -74,6 +74,10 @@ class TransformableBoxController extends ChangeNotifier {
   /// all resizing operations.
   bool resizable = true;
 
+  /// Whether the box should hide the corner/side resize controls when [resizable] is
+  /// false.
+  bool hideHandlesWhenNotResizable = true;
+
   /// Whether to allow flipping of the box while resizing. If this is set to
   /// true, the box will flip when the user drags the handles to opposite
   /// corners of the rect.
@@ -142,6 +146,14 @@ class TransformableBoxController extends ChangeNotifier {
     this.resizable = resizable;
     notifyListeners();
   }
+
+  /// Whether the box should hide the corner/side resize controls when [resizable] is
+  /// false.
+  void setHideHandlesWhenNotResizable(bool hideHandlesWhenNotResizable) {
+    this.hideHandlesWhenNotResizable = hideHandlesWhenNotResizable;
+    notifyListeners();
+  }
+
 
   /// Whether to allow flipping of the box while resizing. If this is set to
   /// true, the box will flip when the user drags the handles to opposite


### PR DESCRIPTION
This PR adds a new flag `hideHandlesWhenNotResizable` which allows user to request that the handles be automatically hidden when not resizable.

This PR also extends the example to include a switch to set hideHandlesWhenNotResizable`, as well as an additional switch to add a second ImageBox() - the model and imagebox have been extended to allow this, as well as generalizing ImageBox() to not be as hard coded to the specific model rect/flip flag and asset image name.

It also adjusts the const declarations so that it does not have analysis issues (which may be because I am on master branch of flutter).
