### PR TITLE
Fix scaled-clamping regression

### DIFF
--- a/packages/box_transform/lib/src/geometry.dart
+++ b/packages/box_transform/lib/src/geometry.dart
@@ -625,6 +625,9 @@ class Box {
   }
 
   /// Constrains the given [child] box instance within the bounds of this box.
+  /// This function will preserve the sign of the child's width and height.
+  /// It will also maintain the aspect ratio of the child if the [aspectRatio]
+  /// is specified.
   ///
   /// [child] the child box to clamp inside this box.
   /// [resizeMode] defines how to contain the child, whether it should keep its
@@ -646,16 +649,21 @@ class Box {
     final double clampedLeft = math.min(x, right - childWidth);
     final double clampedTop = math.min(y, bottom - childHeight);
 
-    double newLeft = math.max(left, clampedLeft);
-    double newTop = math.max(top, clampedTop);
+    final double newLeft = math.max(left, clampedLeft);
+    final double newTop = math.max(top, clampedTop);
     double newWidth = math.min(width, childWidth);
     double newHeight = math.min(height, childHeight);
+
     if (resizeMode.isScalable && aspectRatio != null) {
       final double newAspectRatio = newWidth / newHeight;
+      final double widthAdjustment = newHeight * aspectRatio;
+      final double heightAdjustment = newWidth / aspectRatio;
 
       if (aspectRatio < newAspectRatio) {
+        newHeight = math.min(height, heightAdjustment);
         newWidth = newHeight * aspectRatio;
-      } else {
+      } else if (aspectRatio > newAspectRatio) {
+        newWidth = math.min(width, widthAdjustment);
         newHeight = newWidth / aspectRatio;
       }
     }

--- a/packages/box_transform/lib/src/transformer.dart
+++ b/packages/box_transform/lib/src/transformer.dart
@@ -276,7 +276,6 @@ class BoxTransformer {
     Constraints constraints = const Constraints.unconstrained(),
   }) {
     final double aspectRatio = initialBox.width / initialBox.height;
-    print('aspectRatio:    $aspectRatio');
 
     initialBox = flipBox(initialBox, flip, handle);
     Box rect;

--- a/packages/box_transform/lib/src/transformer.dart
+++ b/packages/box_transform/lib/src/transformer.dart
@@ -276,6 +276,7 @@ class BoxTransformer {
     Constraints constraints = const Constraints.unconstrained(),
   }) {
     final double aspectRatio = initialBox.width / initialBox.height;
+    print('aspectRatio:    $aspectRatio');
 
     initialBox = flipBox(initialBox, flip, handle);
     Box rect;

--- a/packages/flutter_box_transform/example/lib/main.dart
+++ b/packages/flutter_box_transform/example/lib/main.dart
@@ -409,7 +409,7 @@ class _ImageBoxState extends State<ImageBox> {
       resizable: model.resizable,
       hideHandlesWhenNotResizable: model.hideHandlesWhenNotResizable,
       movable: model.movable,
-      flipChild: model.flipChild,
+      allowContentFlipping: model.flipChild,
       flipWhileResizing: model.flipRectWhileResizing,
       onTerminalSizeReached: (
         bool reachedMinWidth,
@@ -429,7 +429,7 @@ class _ImageBoxState extends State<ImageBox> {
           maxHeightReached = reachedMaxHeight;
         });
       },
-      childBuilder: (context, rect, flip) => Container(
+      contentBuilder: (context, rect, flip) => Container(
         width: rect.width,
         height: rect.height,
         decoration: BoxDecoration(
@@ -557,7 +557,7 @@ class _ClampingRectState extends State<ClampingRect> {
         hasShadow: false,
         handleAlign: HandleAlign.inside,
       ),
-      childBuilder: (context, _, flip) => Container(
+      contentBuilder: (context, _, flip) => Container(
         width: model.clampingRect.width,
         height: model.clampingRect.height,
         alignment: Alignment.bottomRight,

--- a/packages/flutter_box_transform/lib/src/transformable_box.dart
+++ b/packages/flutter_box_transform/lib/src/transformable_box.dart
@@ -370,18 +370,12 @@ class _TransformableBoxState extends State<TransformableBox> {
       controller.resolveResizeModeCallback = widget.resolveResizeModeCallback;
     }
 
-    if (oldWidget.clampingRect.left != widget.clampingRect.left ||
-        oldWidget.clampingRect.top != widget.clampingRect.top ||
-        oldWidget.clampingRect.right != widget.clampingRect.right ||
-        oldWidget.clampingRect.bottom != widget.clampingRect.bottom) {
+    if (oldWidget.clampingRect != widget.clampingRect) {
       controller.clampingRect = widget.clampingRect;
       controller.recalculatePosition(notify: false);
     }
 
-    if (oldWidget.constraints.minWidth != widget.constraints.minWidth ||
-        oldWidget.constraints.maxWidth != widget.constraints.maxWidth ||
-        oldWidget.constraints.minHeight != widget.constraints.minHeight ||
-        oldWidget.constraints.maxHeight != widget.constraints.maxHeight) {
+    if (oldWidget.constraints != widget.constraints) {
       controller.constraints = widget.constraints;
       controller.recalculateSize(notify: false);
     }


### PR DESCRIPTION
This PR fixes a long-standing issue with scaling not properly tracking the cursor.

This was due to the clamping box not doing its calculations correctly when trying to contain the main box. The logic has now been corrected.