### PR TITLE
feat: add onTap event and handler to TransformableBox

### DIFF
--- a/packages/flutter_box_transform/lib/src/transformable_box.dart
+++ b/packages/flutter_box_transform/lib/src/transformable_box.dart
@@ -142,6 +142,9 @@ class TransformableBox extends StatefulWidget {
   /// or the flip.
   final RectChangeEvent? onChanged;
 
+  /// A callback that is called every time the [TransformableBox] is tapped.
+  final TapEvent? onTap;
+
   /// A callback that is called when [TransformableBox] triggers a pointer down
   /// event to begin a drag operation.
   final RectDragStartEvent? onDragStart;
@@ -246,6 +249,9 @@ class TransformableBox extends StatefulWidget {
     this.resizable = true,
     this.draggable = true,
     this.allowFlippingWhileResizing = true,
+
+    // Tap events
+    this.onTap,
 
     // Either resize or drag triggers.
     this.onChanged,
@@ -489,6 +495,9 @@ class _TransformableBoxState extends State<TransformableBox> {
     widget.onTerminalSizeReached?.call(false, false, false, false);
   }
 
+  /// Called when the box is tapped.
+  void onTap() => widget.onTap?.call();
+
   /// Called when the box drag event starts.
   void onDragPanStart(DragStartDetails event) {
     // Two fingers were used to start the drag. This produces issues with
@@ -545,6 +554,7 @@ class _TransformableBoxState extends State<TransformableBox> {
     if (widget.draggable) {
       content = GestureDetector(
         behavior: HitTestBehavior.translucent,
+        onTap: onTap,
         onPanStart: onDragPanStart,
         onPanUpdate: onDragPanUpdate,
         onPanEnd: onDragPanEnd,

--- a/packages/flutter_box_transform/lib/src/typedefs.dart
+++ b/packages/flutter_box_transform/lib/src/typedefs.dart
@@ -25,6 +25,9 @@ typedef RectChangeEvent = void Function(
   DragUpdateDetails event,
 );
 
+/// A callback that is called when the box is tapped.
+typedef TapEvent = void Function();
+
 /// A callback that is called when the box begins a drag operation.
 typedef RectDragStartEvent = void Function(
   DragStartDetails event,


### PR DESCRIPTION
Adds a onTap event and handler to TransformableBox.

This is something we ended up needing in our project to be able to show and hide the transform controls during interaction that did not include dragging or otherwise moving the box.

