### PR TITLE
Add parameters for supported devices

### DIFF
--- a/packages/flutter_box_transform/lib/src/handle_builders.dart
+++ b/packages/flutter_box_transform/lib/src/handle_builders.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:box_transform/box_transform.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -16,6 +18,9 @@ class CornerHandleWidget extends StatelessWidget {
 
   /// The size of the handle's gesture response area.
   final double handleTapSize;
+
+  /// The kind of devices that are allowed to be recognized.
+  final Set<PointerDeviceKind> supportedDevices;
 
   /// Called when the handle dragging starts.
   final GestureDragStartCallback? onPanStart;
@@ -43,6 +48,7 @@ class CornerHandleWidget extends StatelessWidget {
     super.key,
     required this.handlePosition,
     required this.handleTapSize,
+    required this.supportedDevices,
     required this.builder,
     this.onPanStart,
     this.onPanUpdate,
@@ -61,6 +67,7 @@ class CornerHandleWidget extends StatelessWidget {
     if (enabled) {
       child = GestureDetector(
         behavior: HitTestBehavior.opaque,
+        supportedDevices: supportedDevices,
         onPanStart: onPanStart,
         onPanUpdate: onPanUpdate,
         onPanEnd: onPanEnd,
@@ -118,6 +125,9 @@ class SideHandleWidget extends StatelessWidget {
   /// The thickness of the handle that is used for gesture detection.
   final double handleTapSize;
 
+  /// The kind of devices that are allowed to be recognized.
+  final Set<PointerDeviceKind> supportedDevices;
+
   /// Called when the handle dragging starts.
   final GestureDragStartCallback? onPanStart;
 
@@ -144,6 +154,7 @@ class SideHandleWidget extends StatelessWidget {
     super.key,
     required this.handlePosition,
     required this.handleTapSize,
+    required this.supportedDevices,
     required this.builder,
     this.onPanStart,
     this.onPanUpdate,
@@ -162,6 +173,7 @@ class SideHandleWidget extends StatelessWidget {
     if (enabled) {
       child = GestureDetector(
         behavior: HitTestBehavior.opaque,
+        supportedDevices: supportedDevices,
         onPanStart: onPanStart,
         onPanUpdate: onPanUpdate,
         onPanEnd: onPanEnd,

--- a/packages/flutter_box_transform/lib/src/transformable_box.dart
+++ b/packages/flutter_box_transform/lib/src/transformable_box.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import '../flutter_box_transform.dart';
@@ -65,6 +66,16 @@ class TransformableBox extends StatefulWidget {
   /// enabled, it will not be interactive. If a handle is enabled but not
   /// visible, it will not be shown and will not be interactive.
   final Set<HandlePosition> visibleHandles;
+
+  /// The kind of devices that are allowed to be recognized for drag events.
+  ///
+  /// By default, events from all device types will be recognized for drag events.
+  final Set<PointerDeviceKind> supportedDragDevices;
+
+  /// The kind of devices that are allowed to be recognized for resize events.
+  ///
+  /// By default, events from all device types will be recognized for resize events.
+  final Set<PointerDeviceKind> supportedResizeDevices;
 
   /// The initial box that will be used to position set the initial size of
   /// the [TransformableBox] widget.
@@ -231,6 +242,8 @@ class TransformableBox extends StatefulWidget {
     this.handleAlignment = HandleAlignment.center,
     this.enabledHandles = const {...HandlePosition.values},
     this.visibleHandles = const {...HandlePosition.values},
+    this.supportedDragDevices = const {...PointerDeviceKind.values},
+    this.supportedResizeDevices = const {...PointerDeviceKind.values},
 
     // Raw values.
     Rect? rect,
@@ -576,6 +589,7 @@ class _TransformableBoxState extends State<TransformableBox> {
     if (widget.draggable) {
       content = GestureDetector(
         behavior: HitTestBehavior.translucent,
+        supportedDevices: widget.supportedDragDevices,
         onTap: onTap,
         onPanStart: onDragPanStart,
         onPanUpdate: onDragPanUpdate,
@@ -606,6 +620,7 @@ class _TransformableBoxState extends State<TransformableBox> {
                 key: ValueKey(handle),
                 handlePosition: handle,
                 handleTapSize: widget.handleTapSize,
+                supportedDevices: widget.supportedResizeDevices,
                 enabled: widget.enabledHandles.contains(handle),
                 visible: widget.visibleHandles.contains(handle),
                 onPanStart: (event) => onHandlePanStart(event, handle),
@@ -622,6 +637,7 @@ class _TransformableBoxState extends State<TransformableBox> {
                 key: ValueKey(handle),
                 handlePosition: handle,
                 handleTapSize: widget.handleTapSize,
+                supportedDevices: widget.supportedResizeDevices,
                 enabled: widget.enabledHandles.contains(handle),
                 visible: widget.visibleHandles.contains(handle),
                 onPanStart: (event) => onHandlePanStart(event, handle),


### PR DESCRIPTION
Allows users to specify which devices they want and don't want to be used for drag and resize events. This prevents a scenario where a trackpad scroll moves the box when it isn't intended to.