### PR TITLE
feat: taps should pass through when onTap is unset

### DIFF
--- a/packages/flutter_box_transform/lib/src/transformable_box.dart
+++ b/packages/flutter_box_transform/lib/src/transformable_box.dart
@@ -125,10 +125,6 @@ class TransformableBox extends StatefulWidget {
   /// all moving operations.
   final bool draggable;
 
-  /// Whether the box ignores tap events and allows them to pass through to widgets
-  /// behind it. Dragging and resizing interactions are still possible.
-  final bool tapThrough;
-
   /// Whether to allow flipping of the box while resizing. If this is set to
   /// true, the box will flip when the user drags the handles to opposite
   /// corners of the rect.
@@ -259,7 +255,6 @@ class TransformableBox extends StatefulWidget {
     // Additional controls.
     this.resizable = true,
     this.draggable = true,
-    this.tapThrough = false,
     this.allowFlippingWhileResizing = true,
 
     // Tap events
@@ -602,7 +597,7 @@ class _TransformableBoxState extends State<TransformableBox> {
       content = GestureDetector(
         behavior: HitTestBehavior.translucent,
         supportedDevices: widget.supportedDragDevices,
-        onTap: widget.tapThrough ? null : onTap,
+        onTap: widget.onTap == null ? null : onTap,
         onPanStart: onDragPanStart,
         onPanUpdate: onDragPanUpdate,
         onPanEnd: onDragPanEnd,

--- a/packages/flutter_box_transform/lib/src/transformable_box.dart
+++ b/packages/flutter_box_transform/lib/src/transformable_box.dart
@@ -125,6 +125,10 @@ class TransformableBox extends StatefulWidget {
   /// all moving operations.
   final bool draggable;
 
+  /// Whether the box ignores tap events and allows them to pass through to widgets
+  /// behind it. Dragging and resizing interactions are still possible.
+  final bool tapThrough;
+
   /// Whether to allow flipping of the box while resizing. If this is set to
   /// true, the box will flip when the user drags the handles to opposite
   /// corners of the rect.
@@ -255,6 +259,7 @@ class TransformableBox extends StatefulWidget {
     // Additional controls.
     this.resizable = true,
     this.draggable = true,
+    this.tapThrough = false,
     this.allowFlippingWhileResizing = true,
 
     // Tap events
@@ -597,7 +602,7 @@ class _TransformableBoxState extends State<TransformableBox> {
       content = GestureDetector(
         behavior: HitTestBehavior.translucent,
         supportedDevices: widget.supportedDragDevices,
-        onTap: onTap,
+        onTap: widget.tapThrough ? null : onTap,
         onPanStart: onDragPanStart,
         onPanUpdate: onDragPanUpdate,
         onPanEnd: onDragPanEnd,


### PR DESCRIPTION
## Issue
Fixes: [Feature Request: TransformableBox should enable onTap Event Propagation to Child Widgets #31](https://github.com/hyper-designed/box_transform/issues/31)

## Problem statement
Currently the `TransformableBox` captures all tap events and  forwards them to the onTap callback. This becomes problematic if we want the content of the `TransformableBox` to capture onTap events (or whatever is rendered behind the box, in case the content is ignoring pointer events).

## Testing
Manual testing have been performed with the following setup:
```dart
// pseudo  code
stack: [
  GeastureDetector(
    onTap: _onTap,
    child: CameraPreview()
  ), 
  TransformableBox(
     // ... //
     tapThrough: true,
      },
      contentBuilder: (context, rect, flip) => IgnorePointer(
        child: DecoratedBox(
          decoration: BoxDecoration(
            border: Border.all(
              width: 2,
            ),
          ),
        ),
      ),
    );
]
```
* When the `onTap` arg was provided, the tap event was captured by the TransformableBox.
* When the `onTap` arg was not provided, the tap event was captured by the CameraPreview's GestureDetector.
